### PR TITLE
support css in hashifyScriptPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-debug-tools",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "./dist/index.js",
   "scripts": {
     "lint": "TIMING=1 ./node_modules/eslint/bin/eslint.js --max-warnings=0 ./src/index.ts",

--- a/src/hashifyScriptPath.ts
+++ b/src/hashifyScriptPath.ts
@@ -11,7 +11,7 @@ export const hashifyScriptPath = (htmlPath: string, scriptPathInHtml: string, sc
   const html = readFileSync(htmlPath)
   const script = readFileSync(scriptPathOnDisk)
   const md5 = createHash('md5').update(script).digest('hex')
-  const htmlString = html.toString('utf-8').replace(`src="${scriptPathInHtml}"`, `src="${scriptPathInHtml}?id=${md5}"`)
+  const htmlString = html.toString('utf-8').replace(`src="${scriptPathInHtml}"`, `src="${scriptPathInHtml}?id=${md5}"`).replace(`href="${scriptPathInHtml}"`, `href="${scriptPathInHtml}?id=${md5}"`)
   const updatedBuffer = Buffer.from(htmlString)
   writeFileSync(htmlPath, updatedBuffer)
 }


### PR DESCRIPTION
Add support for css because `href` attribute is used there instead of `srf` (like in js).